### PR TITLE
Made `GIFImageView` class `open`

### DIFF
--- a/GIFImageView/Classes/GIFImageView.swift
+++ b/GIFImageView/Classes/GIFImageView.swift
@@ -11,11 +11,11 @@ import ImageIO
 
 
 @IBDesignable
-class GIFImageView: UIImageView {
+open class GIFImageView: UIImageView {
     @IBInspectable public var animatedImage: String = ""
     @IBInspectable public var repeatCount: Int = 0 // forever
     
-    override func layoutSubviews() {
+    override open func layoutSubviews() {
         super.layoutSubviews()
         
         if let animation = UIImage.animatedImage(named: self.animatedImage) {


### PR DESCRIPTION
I faced the situation where I need to inherit from the `GIFImageView`. But I was surprised that it's not `open` and even not `public`. So as I understand it's supposed to be used only inside the storyboards. I think making the class `open` expands the number of the pod use-cases.